### PR TITLE
Msgstr for plurals should default to empty string as required for template files

### DIFF
--- a/jgettext/src/main/java/org/fedorahosted/tennera/jgettext/PoWriter.java
+++ b/jgettext/src/main/java/org/fedorahosted/tennera/jgettext/PoWriter.java
@@ -347,13 +347,21 @@ public class PoWriter {
 		writeString(prefix, msgstr, writer, msgSpace.length());
 	}
 
+	protected void writeMsgStrPlural(String prefix, String msgstr, int i, Writer writer) throws IOException {
+		String msgSpace = "msgstr[" + i + "] ";
+		writer.write( prefix + msgSpace);
+		writeString(prefix, msgstr, writer, msgSpace.length());
+	}
+
 	protected void writeMsgstrPlurals(String prefix, List<String> msgstrPlurals, Writer writer) throws IOException {
-		int i = 0;
-		for ( String msgstr : msgstrPlurals ) {
-			String msgSpace = "msgstr[" + i + "] ";
-			writer.write( prefix + msgSpace);
-			writeString(prefix, msgstr, writer, msgSpace.length());
-			i++;
+		if ( msgstrPlurals.isEmpty() ) {
+			writeMsgStrPlural(prefix, "", 0, writer);
+		} else {
+			int i = 0;
+			for ( String msgstr : msgstrPlurals ) {
+				writeMsgStrPlural(prefix, msgstr, i, writer);
+				i++;
+			}
 		}
 	}
 	

--- a/jgettext/src/test/java/org/fedorahosted/tennera/jgettext/TestPoWriter.java
+++ b/jgettext/src/test/java/org/fedorahosted/tennera/jgettext/TestPoWriter.java
@@ -1,0 +1,47 @@
+package org.fedorahosted.tennera.jgettext;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class TestPoWriter {
+
+	private static String serializeMsg(Message msg) throws IOException {
+		Catalog catalog = new Catalog(true);
+		catalog.addMessage(msg);
+		ByteArrayOutputStream bos = new ByteArrayOutputStream();
+		Charset charset = Charset.forName("utf-8");
+		new PoWriter().write(catalog, bos, charset);
+		bos.close();
+		return new String(bos.toByteArray(), charset);
+	}
+
+	@Test
+	public void testDefaultMsgStrShouldBeEmpty() throws IOException {
+		Message msg = new Message();
+		msg.setMsgid("id");
+		
+		String str = serializeMsg(msg);
+		Pattern pattern = Pattern.compile("^msgstr\\s+\"\"$", Pattern.MULTILINE);
+		Matcher matcher = pattern.matcher(str);
+		Assert.assertTrue(matcher.find());
+		Assert.assertFalse(matcher.find());
+	}
+
+	@Test
+	public void testDefaultPluralStrShouldBeEmpty() throws IOException {
+		Message msg = new Message();
+		msg.setMsgid("id");
+		msg.setMsgidPlural("ids");
+
+		String str = serializeMsg(msg);
+		Pattern pattern = Pattern.compile("^msgstr\\[0\\]\\s+\"\"$", Pattern.MULTILINE);
+		Matcher matcher = pattern.matcher(str);
+		Assert.assertTrue(matcher.find());
+		Assert.assertFalse(matcher.find());
+	}
+}


### PR DESCRIPTION
GNU gettext seems to require a `msgtr[0]` entry for plurals in template files. For singulars this is handled in `writeMsgStr` by converting null to the empty string, `WriteMsgStrPlurals` should also output an empty entry if the list of plurals is empty.
